### PR TITLE
Add CORS configuration to allow requests from the browser

### DIFF
--- a/src/main/kotlin/com/zim/pokemon_api/config/CorsConfig.kt
+++ b/src/main/kotlin/com/zim/pokemon_api/config/CorsConfig.kt
@@ -1,0 +1,21 @@
+package com.zim.pokemon_api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfig {
+    @Bean
+    fun corsConfigurer(): WebMvcConfigurer {
+        return object : WebMvcConfigurer {
+            override fun addCorsMappings(registry: CorsRegistry) {
+                registry.addMapping("/**")
+                    .allowedOrigins("http://localhost:5173")
+                    .allowedMethods("GET")
+                    .allowedHeaders("*")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added simple CORS configuration to allow requests from the browser.
Specifically, from `http://localhost:5173`. 

**No changes were made to existing functionality.**

## Clone and run the server

- clone
```bash
git clone https://github.com/zeevjo/pokemon-api.git
cd pokemon-api
git switch dev  
```
- build and run
```bash
./gradlew clean build
./gradlew bootRun
```






